### PR TITLE
Material lib add mat equal

### DIFF
--- a/pyne/material.pyx
+++ b/pyne/material.pyx
@@ -1700,6 +1700,55 @@ class Material(_Material, collections.MutableMapping):
         with open(filename, 'a') as f:
             f.write(self.alara())
 
+    def __eq__(self, other):
+        """Compare self and other material.
+
+        Parameters
+        ----------
+        other : Material
+            The other material to be comparied.
+
+        Returns
+        -------
+        True : bool
+            If self and other have the same value
+        False : bool
+            If self and other are different
+        """
+        # check whether they have the same id
+        if id(self) == id(other):
+            return True
+        # check the type
+        if type(other) != type(self):
+            return False
+        # check the value
+        # comp
+        if self.comp != other.comp:
+            return False
+        # density
+        if self.density != other.density:
+            return False
+        # mass
+        if self.mass != other.mass:
+            return False
+        # atoms_per_molecule
+        if self.atoms_per_molecule != other.atoms_per_molecule:
+            return False
+        # matedata
+        if self.metadata != other.metadata:
+            return False
+        # free_mat
+        if hasattr(self, 'free_mat') == hasattr(other, 'free_mat'):
+            try:
+                if self.free_mat != self.free_mat:
+                    return False
+            except:
+                pass
+        # no difference found
+        return True
+         
+
+
 #####################################
 ### Material generation functions ###
 #####################################

--- a/pyne/material_library.pyx
+++ b/pyne/material_library.pyx
@@ -273,7 +273,10 @@ cdef class _MaterialLibrary:
         return py_mat
     
     def __len__(self):
-        return self.mat_library.size()
+        if hasattr(self, 'mat_library'):
+            return self.mat_library.size()
+        else:
+            return 0
 
     def __delitem__(self, key):
         if isinstance(key, basestring):

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -546,7 +546,7 @@ def test_matlib():
     }
     m = gen_mesh(mats=mats)
     for i, ve in enumerate(mesh_iterate(m.mesh)):
-        assert_is(m.mats[i], mats[i])
+        assert_equal(m.mats[i], mats[i])
         assert_equal(m.mesh.tag_get_data(
             m.mesh.tag_get_handle('idx'), ve, flat=True)[0], i)
 
@@ -870,7 +870,7 @@ def test_iter():
     idx_tag = m.mesh.tag_get_handle('idx')
     for i, mat, ve in m:
         assert_equal(j, i)
-        assert_is(mats[i], mat)
+        assert_equal(mats[i], mat)
         assert_equal(j, m.mesh.tag_get_data(idx_tag, ve, flat=True)[0])
         j += 1
 


### PR DESCRIPTION
Add a simple version `__eq__` to Material for better unit test.
This PR will fix `assert_is(mats[i], mat)` in `test_mesh.py`.
Oops, it breaks `test_mcnp.py`.